### PR TITLE
CTF merges and splits 3 streams of digits

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
@@ -28,6 +28,7 @@ enum class EventType {
   Calib = 1,
   FET = 2
 };
+constexpr uint32_t NEvTypes = 3;
 
 /// ROFRecord class encodes the trigger interaction record of given ROF and
 /// the reference on the 1st object (digit, cluster etc) of this ROF in the data tree
@@ -40,6 +41,7 @@ struct ROFRecord {
   ROFRecord() = default;
   ROFRecord(const o2::InteractionRecord& intRecord, const EventType& evtType, size_t first, size_t nElements) : interactionRecord(intRecord), eventType(evtType), firstEntry(first), nEntries(nElements) {}
   ROFRecord(const ROFRecord& other, size_t first, size_t nElements) : interactionRecord(other.interactionRecord), eventType(other.eventType), firstEntry(first), nEntries(nElements) {}
+  size_t getEndIndex() const { return firstEntry + nEntries; }
 
   ClassDefNV(ROFRecord, 1);
 };

--- a/Detectors/CTF/test/test_ctf_io_mid.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mid.cxx
@@ -26,8 +26,9 @@ using namespace o2::mid;
 
 BOOST_AUTO_TEST_CASE(CTFTest)
 {
-  std::vector<ROFRecord> rofs;
-  std::vector<ColumnData> cols;
+  std::array<std::vector<ColumnData>, NEvTypes> colData{};
+  std::array<std::vector<ROFRecord>, NEvTypes> rofData{};
+  CTFHelper::TFData tfData;
   // RS: don't understand why, but this library is not loaded automatically, although the dependencies are clearly
   // indicated. What it more weird is that for similar tests of other detectors the library is loaded!
   // Absence of the library leads to complains about the StreamerInfo and eventually segm.faul when appending the
@@ -39,27 +40,37 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   std::array<uint16_t, 5> pattern;
   for (int irof = 0; irof < 1000; irof++) {
     ir += 1 + gRandom->Integer(200);
-    uint8_t nch = 0, evtyp = gRandom->Integer(3);
-    while (nch == 0) {
-      nch = gRandom->Poisson(10);
-    }
-    auto start = cols.size();
-    for (int ich = 0; ich < nch; ich++) {
-      uint8_t deId = gRandom->Integer(128);
-      uint8_t columnId = gRandom->Integer(128);
-      for (int i = 0; i < 5; i++) {
-        pattern[i] = gRandom->Integer(0x7fff);
+    for (uint8_t evtyp = 0; evtyp < NEvTypes; evtyp++) {
+      if (gRandom->Rndm() > 0.8) {
+        continue; // sometimes skip some event types
       }
-      cols.emplace_back(ColumnData{deId, columnId, pattern});
+      uint8_t nch = 0;
+      while (nch == 0) {
+        nch = gRandom->Poisson(10);
+      }
+      auto start = colData[evtyp].size();
+      for (int ich = 0; ich < nch; ich++) {
+        uint8_t deId = gRandom->Integer(128);
+        uint8_t columnId = gRandom->Integer(128);
+        for (int i = 0; i < 5; i++) {
+          pattern[i] = gRandom->Integer(0x7fff);
+        }
+        colData[evtyp].emplace_back(ColumnData{deId, columnId, pattern});
+      }
+      rofData[evtyp].emplace_back(ROFRecord{ir, EventType(evtyp), start, colData[evtyp].size() - start});
     }
-    rofs.emplace_back(ROFRecord{ir, EventType(evtyp), start, cols.size() - start});
   }
+  for (uint32_t i = 0; i < NEvTypes; i++) {
+    tfData.colData[i] = {colData[i].data(), colData[i].size()};
+    tfData.rofData[i] = {rofData[i].data(), rofData[i].size()};
+  }
+  tfData.buildReferences();
 
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
     CTFCoder coder;
-    coder.encode(vec, rofs, cols); // compress
+    coder.encode(vec, tfData); // compress
   }
   sw.Stop();
   LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
@@ -89,42 +100,49 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
   }
 
-  std::vector<ROFRecord> rofsD;
-  std::vector<ColumnData> colsD;
+  std::array<std::vector<ColumnData>, NEvTypes> colDataD{};
+  std::array<std::vector<ROFRecord>, NEvTypes> rofDataD{};
 
   sw.Start();
   const auto ctfImage = o2::mid::CTF::getImage(vec.data());
   {
     CTFCoder coder;
-    coder.decode(ctfImage, rofsD, colsD); // decompress
+    coder.decode(ctfImage, rofDataD, colDataD); // decompress
   }
   sw.Stop();
   LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
 
-  BOOST_CHECK(rofsD.size() == rofs.size());
-  BOOST_CHECK(colsD.size() == cols.size());
-  LOG(INFO) << " BOOST_CHECK rofsD.size() " << rofsD.size() << " rofs.size() " << rofs.size()
-            << " BOOST_CHECK(colsD.size() " << colsD.size() << " cols.size()) " << cols.size();
+  for (uint32_t it = 0; it < NEvTypes; it++) {
+    const auto& rofsD = rofDataD[it];
+    const auto& rofs = rofData[it];
+    const auto& colsD = colDataD[it];
+    const auto& cols = colData[it];
+    LOG(INFO) << "Test for event type " << it;
+    BOOST_CHECK(rofsD.size() == rofs.size());
+    BOOST_CHECK(colsD.size() == cols.size());
+    LOG(INFO) << " BOOST_CHECK rofsD.size() " << rofsD.size() << " rofs.size() " << rofData[0].size()
+              << " BOOST_CHECK(colsD.size() " << colsD.size() << " cols.size()) " << colData[0].size();
 
-  for (size_t i = 0; i < rofs.size(); i++) {
-    const auto& dor = rofs[i];
-    const auto& ddc = rofsD[i];
-    LOG(DEBUG) << " Orig.ROFRecord " << i << " " << dor.interactionRecord << " " << dor.firstEntry << " " << dor.nEntries;
-    LOG(DEBUG) << " Deco.ROFRecord " << i << " " << ddc.interactionRecord << " " << ddc.firstEntry << " " << ddc.nEntries;
+    for (size_t i = 0; i < rofs.size(); i++) {
+      const auto& dor = rofs[i];
+      const auto& ddc = rofsD[i];
+      LOG(DEBUG) << " Orig.ROFRecord " << i << " " << dor.interactionRecord << " " << dor.firstEntry << " " << dor.nEntries;
+      LOG(DEBUG) << " Deco.ROFRecord " << i << " " << ddc.interactionRecord << " " << ddc.firstEntry << " " << ddc.nEntries;
 
-    BOOST_CHECK(dor.interactionRecord == ddc.interactionRecord);
-    BOOST_CHECK(dor.firstEntry == ddc.firstEntry);
-    BOOST_CHECK(dor.nEntries == dor.nEntries);
-  }
+      BOOST_CHECK(dor.interactionRecord == ddc.interactionRecord);
+      BOOST_CHECK(dor.firstEntry == ddc.firstEntry);
+      BOOST_CHECK(dor.nEntries == dor.nEntries);
+    }
 
-  for (size_t i = 0; i < cols.size(); i++) {
-    const auto& cor = cols[i];
-    const auto& cdc = colsD[i];
-    BOOST_CHECK(cor.deId == cdc.deId);
-    BOOST_CHECK(cor.columnId == cdc.columnId);
-    for (int j = 0; j < 5; j++) {
-      BOOST_CHECK(cor.patterns[j] == cdc.patterns[j]);
-      LOG(DEBUG) << "col " << i << " pat " << j << " : " << cor.patterns[j] << " : " << cdc.patterns[j];
+    for (size_t i = 0; i < cols.size(); i++) {
+      const auto& cor = cols[i];
+      const auto& cdc = colsD[i];
+      BOOST_CHECK(cor.deId == cdc.deId);
+      BOOST_CHECK(cor.columnId == cdc.columnId);
+      for (int j = 0; j < 5; j++) {
+        BOOST_CHECK(cor.patterns[j] == cdc.patterns[j]);
+        LOG(DEBUG) << "col " << i << " pat " << j << " : " << cor.patterns[j] << " : " << cdc.patterns[j];
+      }
     }
   }
 }

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -42,22 +42,22 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const ColumnData>& colData);
+  void encode(VEC& buff, const CTFHelper::TFData& tfData);
 
   /// entropy decode data from buffer with CTF
   template <typename VROF, typename VCOL>
-  void decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec);
+  void decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec);
 
   void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
 
  private:
   void appendToTree(TTree& tree, CTF& ec);
-  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<ColumnData>& colVec);
+  void readFromTree(TTree& tree, int entry, std::array<std::vector<ROFRecord>, NEvTypes>& rofVec, std::array<std::vector<ColumnData>, NEvTypes>& colVec);
 };
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const ColumnData>& colData)
+void CTFCoder::encode(VEC& buff, const CTFHelper::TFData& tfData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -70,7 +70,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, cons
     MD::EENCODE, // BLC_deId
     MD::EENCODE  // BLC_colId
   };
-  CTFHelper helper(rofData, colData);
+  CTFHelper helper(tfData);
 
   // book output size with some margin
   auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
@@ -99,7 +99,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, cons
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VROF, typename VCOL>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec)
+void CTFCoder::decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec)
 {
   auto header = ec.getHeader();
   ec.print(getPrefix());
@@ -119,10 +119,12 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec)
   DECODEMID(colId,       CTF::BLC_colId);
   // clang-format on
   //
-  rofVec.clear();
-  colVec.clear();
-  rofVec.reserve(header.nROFs);
-  colVec.reserve(header.nColumns);
+  for (uint32_t i = 0; i < NEvTypes; i++) {
+    rofVec[i].clear();
+    colVec[i].clear();
+    rofVec[i].reserve(header.nROFs);
+    colVec[i].reserve(header.nColumns);
+  }
 
   uint32_t firstEntry = 0, rofCount = 0, colCount = 0, pCount = 0;
   o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
@@ -135,14 +137,14 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec)
     } else {
       ir.bc += bcInc[irof];
     }
-
-    firstEntry = colVec.size();
+    auto& cv = colVec[evType[irof]];
+    firstEntry = cv.size();
     for (uint8_t ic = 0; ic < entries[irof]; ic++) {
-      colVec.emplace_back(ColumnData{deId[colCount], colId[colCount], std::array{pattern[pCount], pattern[pCount + 1], pattern[pCount + 2], pattern[pCount + 3], pattern[pCount + 4]}});
+      cv.emplace_back(ColumnData{deId[colCount], colId[colCount], std::array{pattern[pCount], pattern[pCount + 1], pattern[pCount + 2], pattern[pCount + 3], pattern[pCount + 4]}});
       pCount += 5;
       colCount++;
     }
-    rofVec.emplace_back(ROFRecord{ir, EventType(evType[irof]), firstEntry, entries[irof]});
+    rofVec[evType[irof]].emplace_back(ROFRecord{ir, EventType(evType[irof]), firstEntry, entries[irof]});
   }
   assert(colCount == header.nColumns);
 }

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
@@ -18,6 +18,7 @@
 #include "DataFormatsMID/ROFRecord.h"
 #include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/CTF.h"
+#include "CommonDataFormat/AbstractRef.h"
 #include <gsl/span>
 
 namespace o2
@@ -29,20 +30,31 @@ class CTFHelper
 {
 
  public:
-  CTFHelper(const gsl::span<const o2::mid::ROFRecord>& rofData, const gsl::span<const o2::mid::ColumnData>& colData)
-    : mROFData(rofData), mColData(colData) {}
+  using OrderRef = o2::dataformats::AbstractRef<29, 2, 1>; // 29 bits for index in event type span, 2 bits for event type, 1 bit flag
+  struct TFData {
+    std::vector<OrderRef> colDataRefs{};
+    std::vector<OrderRef> rofDataRefs{};
+    std::array<gsl::span<const o2::mid::ColumnData>, NEvTypes> colData{};
+    std::array<gsl::span<const o2::mid::ROFRecord>, NEvTypes> rofData{};
+    void buildReferences();
+  };
+
+  CTFHelper(const TFData& data) : mTFData(data) {}
+  CTFHelper() = delete;
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mColData.size()), 0, 0};
-    if (mROFData.size()) {
-      h.firstOrbit = mROFData[0].interactionRecord.orbit;
-      h.firstBC = mROFData[0].interactionRecord.bc;
+    CTFHeader h{uint32_t(mTFData.rofDataRefs.size()), uint32_t(mTFData.colDataRefs.size()), 0, 0};
+    if (h.nROFs) {
+      auto id0 = mTFData.rofDataRefs.front();
+      const auto& rof = mTFData.rofData[id0.getSource()][id0.getIndex()];
+      h.firstOrbit = rof.interactionRecord.orbit;
+      h.firstBC = rof.interactionRecord.bc;
     }
     return h;
   }
 
-  size_t getSize() const { return mROFData.size() * sizeof(o2::mid::ROFRecord) + mColData.size() * sizeof(o2::mid::ColumnData); }
+  size_t getSize() const { return mTFData.rofDataRefs.size() * sizeof(o2::mid::ROFRecord) + mTFData.colDataRefs.size() * sizeof(o2::mid::ColumnData); }
 
   //>>> =========================== ITERATORS ========================================
 
@@ -56,7 +68,7 @@ class CTFHelper
     using reference = const T&;
     using iterator_category = std::random_access_iterator_tag;
 
-    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter(const std::vector<OrderRef>& ord, const std::array<gsl::span<const D>, NEvTypes>& data, bool end = false) : mOrder(ord), mData(&data), mIndex(end ? M * ord.size() : 0) {}
     _Iter() = default;
 
     const I& operator++()
@@ -87,7 +99,8 @@ class CTFHelper
     bool operator<(const I& other) const { return mIndex < other.mIndex; }
 
    protected:
-    gsl::span<const D> mData{};
+    gsl::span<const OrderRef> mOrder{};
+    const std::array<gsl::span<const D>, NEvTypes>* mData{};
     size_t mIndex = 0;
   };
 
@@ -100,11 +113,13 @@ class CTFHelper
     using _Iter<Iter_bcIncROF, ROFRecord, uint16_t>::_Iter;
     value_type operator*() const
     {
+      const auto ir = (*mData)[mOrder[mIndex].getSource()][mOrder[mIndex].getIndex()].interactionRecord;
       if (mIndex) {
-        if (mData[mIndex].interactionRecord.orbit == mData[mIndex - 1].interactionRecord.orbit) {
-          return mData[mIndex].interactionRecord.bc - mData[mIndex - 1].interactionRecord.bc;
+        const auto irP = (*mData)[mOrder[mIndex - 1].getSource()][mOrder[mIndex - 1].getIndex()].interactionRecord;
+        if (ir.orbit == irP.orbit) {
+          return ir.bc - irP.bc;
         } else {
-          return mData[mIndex].interactionRecord.bc;
+          return ir.bc;
         }
       }
       return 0;
@@ -117,7 +132,15 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>::_Iter;
-    value_type operator*() const { return mIndex ? mData[mIndex].interactionRecord.orbit - mData[mIndex - 1].interactionRecord.orbit : 0; }
+    value_type operator*() const
+    {
+      if (mIndex) {
+        const auto ir = (*mData)[mOrder[mIndex].getSource()][mOrder[mIndex].getIndex()].interactionRecord;
+        const auto irP = (*mData)[mOrder[mIndex - 1].getSource()][mOrder[mIndex - 1].getIndex()].interactionRecord;
+        return ir.orbit - irP.orbit;
+      }
+      return 0;
+    }
   };
 
   //_______________________________________________
@@ -126,7 +149,7 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_entriesROF, ROFRecord, uint16_t>::_Iter;
-    value_type operator*() const { return mData[mIndex].nEntries; }
+    value_type operator*() const { return (*mData)[mOrder[mIndex].getSource()][mOrder[mIndex].getIndex()].nEntries; }
   };
 
   //_______________________________________________
@@ -135,7 +158,7 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_evtypeROF, ROFRecord, uint8_t>::_Iter;
-    value_type operator*() const { return value_type(mData[mIndex].eventType); }
+    value_type operator*() const { return value_type((*mData)[mOrder[mIndex].getSource()][mOrder[mIndex].getIndex()].eventType); }
   };
 
   //_______________________________________________
@@ -143,7 +166,11 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_pattern, ColumnData, uint16_t, 5>::_Iter;
-    value_type operator*() const { return mData[mIndex / 5].patterns[mIndex % 5]; }
+    value_type operator*() const
+    {
+      auto idx = mOrder[mIndex / 5];
+      return (*mData)[idx.getSource()][idx.getIndex()].patterns[mIndex % 5];
+    }
   };
 
   //_______________________________________________
@@ -151,7 +178,11 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_deId, ColumnData, uint8_t>::_Iter;
-    value_type operator*() const { return mData[mIndex].deId; }
+    value_type operator*() const
+    {
+      auto idx = mOrder[mIndex];
+      return (*mData)[idx.getSource()][idx.getIndex()].deId;
+    }
   };
 
   //_______________________________________________
@@ -159,35 +190,38 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_colId, ColumnData, uint8_t>::_Iter;
-    value_type operator*() const { return mData[mIndex].columnId; }
+    value_type operator*() const
+    {
+      auto idx = mOrder[mIndex];
+      return (*mData)[idx.getSource()][idx.getIndex()].columnId;
+    }
   };
 
   //<<< =========================== ITERATORS ========================================
 
-  Iter_bcIncROF begin_bcIncROF() const { return Iter_bcIncROF(mROFData, false); }
-  Iter_bcIncROF end_bcIncROF() const { return Iter_bcIncROF(mROFData, true); }
+  Iter_bcIncROF begin_bcIncROF() const { return Iter_bcIncROF(mTFData.rofDataRefs, mTFData.rofData, false); }
+  Iter_bcIncROF end_bcIncROF() const { return Iter_bcIncROF(mTFData.rofDataRefs, mTFData.rofData, true); }
 
-  Iter_orbitIncROF begin_orbitIncROF() const { return Iter_orbitIncROF(mROFData, false); }
-  Iter_orbitIncROF end_orbitIncROF() const { return Iter_orbitIncROF(mROFData, true); }
+  Iter_orbitIncROF begin_orbitIncROF() const { return Iter_orbitIncROF(mTFData.rofDataRefs, mTFData.rofData, false); }
+  Iter_orbitIncROF end_orbitIncROF() const { return Iter_orbitIncROF(mTFData.rofDataRefs, mTFData.rofData, true); }
 
-  Iter_entriesROF begin_entriesROF() const { return Iter_entriesROF(mROFData, false); }
-  Iter_entriesROF end_entriesROF() const { return Iter_entriesROF(mROFData, true); }
+  Iter_entriesROF begin_entriesROF() const { return Iter_entriesROF(mTFData.rofDataRefs, mTFData.rofData, false); }
+  Iter_entriesROF end_entriesROF() const { return Iter_entriesROF(mTFData.rofDataRefs, mTFData.rofData, true); }
 
-  Iter_evtypeROF begin_evtypeROF() const { return Iter_evtypeROF(mROFData, false); }
-  Iter_evtypeROF end_evtypeROF() const { return Iter_evtypeROF(mROFData, true); }
+  Iter_evtypeROF begin_evtypeROF() const { return Iter_evtypeROF(mTFData.rofDataRefs, mTFData.rofData, false); }
+  Iter_evtypeROF end_evtypeROF() const { return Iter_evtypeROF(mTFData.rofDataRefs, mTFData.rofData, true); }
 
-  Iter_pattern begin_pattern() const { return Iter_pattern(mColData, false); }
-  Iter_pattern end_pattern() const { return Iter_pattern(mColData, true); }
+  Iter_pattern begin_pattern() const { return Iter_pattern(mTFData.colDataRefs, mTFData.colData, false); }
+  Iter_pattern end_pattern() const { return Iter_pattern(mTFData.colDataRefs, mTFData.colData, true); }
 
-  Iter_deId begin_deId() const { return Iter_deId(mColData, false); }
-  Iter_deId end_deId() const { return Iter_deId(mColData, true); }
+  Iter_deId begin_deId() const { return Iter_deId(mTFData.colDataRefs, mTFData.colData, false); }
+  Iter_deId end_deId() const { return Iter_deId(mTFData.colDataRefs, mTFData.colData, true); }
 
-  Iter_colId begin_colId() const { return Iter_colId(mColData, false); }
-  Iter_colId end_colId() const { return Iter_colId(mColData, true); }
+  Iter_colId begin_colId() const { return Iter_colId(mTFData.colDataRefs, mTFData.colData, false); }
+  Iter_colId end_colId() const { return Iter_colId(mTFData.colDataRefs, mTFData.colData, true); }
 
  private:
-  const gsl::span<const o2::mid::ROFRecord> mROFData;
-  const gsl::span<const o2::mid::ColumnData> mColData;
+  const TFData& mTFData;
 };
 
 } // namespace mid

--- a/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
@@ -27,7 +27,8 @@ void CTFCoder::appendToTree(TTree& tree, CTF& ec)
 
 ///___________________________________________________________________________________
 // extract and decode data from the tree
-void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<ColumnData>& colVec)
+void CTFCoder::readFromTree(TTree& tree, int entry, std::array<std::vector<ROFRecord>, NEvTypes>& rofVec,
+                            std::array<std::vector<ColumnData>, NEvTypes>& colVec)
 {
   assert(entry >= 0 && entry < tree.GetEntries());
   CTF ec;

--- a/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
@@ -13,3 +13,35 @@
 /// \brief  Helper for MID CTF creation
 
 #include "MIDCTF/CTFHelper.h"
+
+using namespace o2::mid;
+
+void CTFHelper::TFData::buildReferences()
+{
+  uint32_t nDone = 0, idx[NEvTypes] = {};
+  uint32_t sizes[NEvTypes] = {
+    uint32_t(rofData[size_t(EventType::Standard)].size()),
+    uint32_t(rofData[size_t(EventType::Calib)].size()),
+    uint32_t(rofData[size_t(EventType::FET)].size())};
+  uint64_t rofBC[NEvTypes] = {};
+  auto fillNextROFBC = [&nDone, &rofBC, &idx, &sizes, this](int it) {
+    if (idx[it] < sizes[it]) {
+      rofBC[it] = this->rofData[it][idx[it]].interactionRecord.toLong();
+    } else {
+      rofBC[it] = -1;
+      nDone++;
+    }
+  };
+  for (uint32_t it = 0; it < NEvTypes; it++) {
+    fillNextROFBC(it);
+  }
+  while (nDone < NEvTypes) { // find next ROFRecord with smallest BC, untill all 3 spans are traversed
+    int selT = rofBC[0] <= rofBC[1] ? (rofBC[0] <= rofBC[2] ? 0 : 2) : (rofBC[1] <= rofBC[2] ? 1 : 2);
+    rofDataRefs.emplace_back(idx[selT], selT);
+    for (uint32_t ic = rofData[selT][idx[selT]].firstEntry; ic < rofData[selT][idx[selT]].getEndIndex(); ic++) {
+      colDataRefs.emplace_back(ic, selT); // register indices of corresponding column data
+    }
+    ++idx[selT]; // increment used index
+    fillNextROFBC(selT);
+  }
+}


### PR DESCRIPTION
Hi @dstocco 

Here is the patch to create/read CTF from up to 3 digits streams with SubSpecs 0,1,2.
But I don't see much point in decoding raw data to 3 streams, then merging it to 1 CTF. Perhaps you can add to raw data decoded an option e.g. `--no-event-splitting` which would send all the event types in a single ROFRecord / ColumnData. The code will handle this and on CTF decoding will create 3 different streams. The only requirement is that in any stream the ROFRecords are ordered in `InteractionRecord`.

Cheers,
 Ruben